### PR TITLE
Use 'sudo -u' not 'sudo su' construction

### DIFF
--- a/articles/sentinel/connect-syslog.md
+++ b/articles/sentinel/connect-syslog.md
@@ -72,8 +72,8 @@ Having already set up [data collection from your CEF sources](connect-common-eve
 
 1. You must run the following command on those machines to disable the synchronization of the agent with the Syslog configuration in Microsoft Sentinel. This ensures that the configuration change you made in the previous step does not get overwritten.
 
-    ```c
-    sudo su omsagent -c 'python /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py --disable'
+    ```bash
+    sudo -u omsagent python /opt/microsoft/omsconfig/Scripts/OMS_MetaConfigHelper.py --disable
     ```
 
 ## Configure your device's logging settings


### PR DESCRIPTION
sudo already gives you the ability to run a command as another user. There's no need to chain sudo and su together.